### PR TITLE
Use file_line instead of exec to prevent duplicate lines in bashrc

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'markea-bashrc'
-version '0.1.0'
+version '0.1.1'
 description "a module to add systemic bashrc changes"
 author 'wolfspyre'
 source 'https://github.com/MelonSmasher/puppet-bashrc.git'

--- a/Modulefile
+++ b/Modulefile
@@ -1,3 +1,7 @@
-name 'wolfspyre-bashrc'
-version '0.1.1'
+name 'markea-bashrc'
+version '0.1.0'
 description "a module to add systemic bashrc changes"
+author 'wolfspyre'
+source 'https://github.com/MelonSmasher/puppet-bashrc.git'
+project_page 'https://github.com/MelonSmasher/puppet-bashrc'
+summary 'a module to add systemic bashrc changes'

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -1,39 +1,43 @@
 # == Class: bashrc::setup
 #
-#This class manages the bashrc additions.
+# This class manages the bashrc additions.
 #
 class bashrc::setup {
   Class['bashrc::setup'] -> Anchor['bashrc::config::end']
-  include bashrc #make our parameters local scope
-  File{} -> Anchor['bashrc::config::end']
-  Exec{} -> Anchor['bashrc::config::end']
-  $bashrcdir   = $bashrc::bashrcdir
+  include bashrc # make our parameters local scope
+  File { } -> Anchor['bashrc::config::end']
+  Exec { } -> Anchor['bashrc::config::end']
+  $bashrcdir = $bashrc::bashrcdir
   $etcbashfile = $bashrc::etcbashfile
+
   file { $bashrcdir:
     ensure => directory,
     owner  => 'root',
     group  => 'root',
     mode   => '0555',
     purge  => true,
-  }#end directory
+  } # end directory
+
   file { '/etc/skel/.bashrc':
-    ensure  => 'file',
-    group   => '0',
-    mode    => '0644',
-    owner   => '0',
+    ensure => 'file',
+    group  => '0',
+    mode   => '0644',
+    owner  => '0',
   }
 
-  exec { 'bashrc_append':
-    command => "/bin/echo 'for i in ${bashrcdir}/*.sh ; do . \$i >/dev/null 2>&1; done' >>${etcbashfile}",
-    unless  => "/bin/grep bashrc.d/\\*.sh ${etcbashfile}",
+  file_line { 'bashrc_append':
+    line   => "/bin/echo 'for i in ${bashrcdir}/*.sh ; do . \$i >/dev/null 2>&1; done' >>${etcbashfile}",
+    ensure => present,
+    path   => "${etcbashfile}",
   }
+
   case $::osfamily {
-    Debian: {
-      #we need to add sourcing of bashrc.d to /etc/bash_completion to accomodate users already existing.
+    Debian : {
+      # we need to add sourcing of bashrc.d to /etc/bash_completion to accomodate users already existing.
       exec { 'bash_completion_append':
         command => "/bin/echo 'for i in ${bashrcdir}/*.sh ; do . \$i >/dev/null 2>&1; done' >>/etc/bash_completion",
         unless  => '/bin/grep bashrc.d/\\*.sh /etc/bash_completion',
       }
     }
   }
-}#end of bashrc::setup class
+} # end of bashrc::setup class

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -24,7 +24,7 @@ class bashrc::setup {
   }
 
   file_line { 'bashrc_append':
-    line   => "/bin/echo 'for i in ${bashrcdir}/*.sh ; do . \$i >/dev/null 2>&1; done' >>${etcbashfile}",
+    line   => "for i in ${bashrcdir}/*.sh ; do . \$i >/dev/null 2>&1; done",
     ensure => present,
     path   => "${etcbashfile}",
   }

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -1,28 +1,26 @@
 # == Class: bashrc::setup
 #
-# This class manages the bashrc additions.
+#This class manages the bashrc additions.
 #
 class bashrc::setup {
   Class['bashrc::setup'] -> Anchor['bashrc::config::end']
-  include bashrc # make our parameters local scope
-  File { } -> Anchor['bashrc::config::end']
-  Exec { } -> Anchor['bashrc::config::end']
-  $bashrcdir = $bashrc::bashrcdir
+  include bashrc #make our parameters local scope
+  File{} -> Anchor['bashrc::config::end']
+  Exec{} -> Anchor['bashrc::config::end']
+  $bashrcdir   = $bashrc::bashrcdir
   $etcbashfile = $bashrc::etcbashfile
-
   file { $bashrcdir:
     ensure => directory,
     owner  => 'root',
     group  => 'root',
     mode   => '0555',
     purge  => true,
-  } # end directory
-
+  }#end directory
   file { '/etc/skel/.bashrc':
-    ensure => 'file',
-    group  => '0',
-    mode   => '0644',
-    owner  => '0',
+    ensure  => 'file',
+    group   => '0',
+    mode    => '0644',
+    owner   => '0',
   }
 
   file_line { 'bashrc_append':
@@ -30,14 +28,14 @@ class bashrc::setup {
     ensure => present,
     path   => "${etcbashfile}",
   }
-
+  
   case $::osfamily {
-    Debian : {
-      # we need to add sourcing of bashrc.d to /etc/bash_completion to accomodate users already existing.
+    Debian: {
+      #we need to add sourcing of bashrc.d to /etc/bash_completion to accomodate users already existing.
       exec { 'bash_completion_append':
         command => "/bin/echo 'for i in ${bashrcdir}/*.sh ; do . \$i >/dev/null 2>&1; done' >>/etc/bash_completion",
         unless  => '/bin/grep bashrc.d/\\*.sh /etc/bash_completion',
       }
     }
   }
-} # end of bashrc::setup class
+}#end of bashrc::setup class


### PR DESCRIPTION
Ignore the Modulefile, this request pertains to manifests/setup.pp.

I've replaced the exec stanza with a file_line stanza to avoid duplicate entries in the bashrc file.
