### PR TITLE
Fix for double ']' and git prompt

### DIFF
--- a/templates/prompt.sh.erb
+++ b/templates/prompt.sh.erb
@@ -41,9 +41,9 @@ else
   left="#{leftblock}"
   middle="#{separator}"
   if enablegit == true
-    right="#{rightblock}]"
+    right="#{rightblock}\$(__git_ps1)"
   else
-    right="#{rightblock}\$(__git_ps1)]"
+    right="#{rightblock}"
    end
 end
 -%>


### PR DESCRIPTION
When not using colors, there is a double ']' at the end of the prompt.
Also the git_ps1 was in the wrong statement result.
